### PR TITLE
Default to print-method

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,13 @@ one arg (an instance of that class), and return a vector whose first element is
 a namespaced keyword that will become the tag in the resulting EDN and whose
 second element is the EDN-encodable value you want to follow the tag.
 
+`edn-encode` can also return a fn that takes one argument: an instance of
+`java.io.Writer`. This fn will be called with the appropriate Writer when
+generating EDN via paradise. This was built to support deferring to
+`print-method` (which takes a Writer) by default so that EDN printing defined
+via the traditional mechanism (vs. via paradise's method) would still work with
+paradise's `edn/write` & `edn/write-string` fns.
+
 `edn-read` is a multi-method that dispatches on `first`. Its purpose is to
 associate reader fns with EDN tags so that they can be turned back into their
 original values. To define new methods, just specify a `defmethod` form with
@@ -72,6 +79,18 @@ the namespaced keyword representing the EDN tag as the dispatch value, take one
 arg (a 2-element vector of \[tag value]; feel encouraged to destructure that),
 and return the EDN representation converted back into an instance of the
 original class. 
+
+### data readers
+
+Data readers defined outside paradise (by you or by libraries you use) should
+Just Work in paradise. The `paradise.edn/read` & `read-string` fns call their
+`clojure.edn` counterparts under the hood.
+
+### print-methods
+
+`print-method` methods defined by you or libraries you use should Just Work in
+paradise. This is because the default `edn-encode` method just defers to
+`print-method`.
 
 ## License
 

--- a/src/paradise/core.clj
+++ b/src/paradise/core.clj
@@ -7,16 +7,24 @@
 
 (defmulti edn-read first)
 
-(defmethod print-method ::edn [[tag value] ^Writer w]
+(defmethod print-method ::edn-tagged [[tag value] ^Writer w]
   (.write w (str "#" (-> tag namespace)
                  "/" (-> tag name) " "))
   (print-method value w))
 
+(defmethod print-method ::edn-printer [print-edn ^Writer w]
+  (print-edn w))
+
 (defn add-metadata [encoded]
-  (if (and (vector? encoded)
-           (= 2 (count encoded)))
-    (vary-meta encoded assoc :type ::edn)
-    encoded))
+  (cond
+    (and (vector? encoded)
+         (= 2 (count encoded)))
+    (vary-meta encoded assoc :type ::edn-tagged)
+
+    (fn? encoded)
+    (vary-meta encoded assoc :type ::edn-printer)
+
+    :else encoded))
 
 (defn read-edn [tag value]
   (try

--- a/src/paradise/defaults.clj
+++ b/src/paradise/defaults.clj
@@ -54,9 +54,9 @@
 (defmethod edn-encodable? Ratio [_] true)
 
 
-;; edn-encode default of .toString
+;; edn-encode default of calling `print-method`
 
-(defmethod edn-encode Object [o] (.toString o))
+(defmethod edn-encode Object [o] (partial print-method o))
 
 
 ;; edn-encode & edn-read methods for common things EDN should handle out of


### PR DESCRIPTION
I realized that paradise wasn't playing nicely with existing / external `print-method` methods when it probably should. We can't expect everyone and every library to define their EDN encodings using paradise, after all.

This fixes that oversight.